### PR TITLE
Improve the plaintext notification email by adding newlines.

### DIFF
--- a/views/email/notification.txt
+++ b/views/email/notification.txt
@@ -1,7 +1,7 @@
 Hello <%= defined?(username) ? username : 'dear user' %> :)
 <%= notifications_text %>
-
-<% for event in events %><% if defined?(event['day']) and !event['day'].nil? %><%= event['day'] %><% end %><%= event['text'] %><% end %>
+<% for event in events %>
++ <% if defined?(event['day']) and !event['day'].nil? %>[<%= event['day'] %>] <% end %><%= event['text'] %><% end %>
 
 View your full notifications history: <%= site_url %>
 


### PR DESCRIPTION
Hi @andreausu,

Sometimes I use a plaintext-only email client and the plaintext notifications look like:

```
Hello bamos :)
You have 2 new notifications!<br />Your last notification was received on Monday Dec 28 at  7:32.

userX starred repo1userY forked repo2 to userY/repo2

View your full notifications history: https://gitnotifier.io/?utm_source=notifications&utm_medium=email&utm_campaign=timeline&utm_content=daily
```

This pull request partially fixes the template for plaintext notifications by adding newlines.

I'm testing with the following script:

```Ruby
#!/usr/bin/env ruby

require 'erb'

notifications_text = "You have 2 new notifications!<br />Your last notification was received on Monday Dec 28 at  7:32."
events = [
  {'day' => '2015-12-28', 'text' => 'userX starred repo1'},
  {'text' => 'userY forked repo2 to userY/repo2'},
  {'day' => '2015-12-28', 'text' => 'userX starred repo1'}
]

site_url = "<site url>"
unsubscribe_url = "<unsubscribe url>"

notificationBody = ERB.new(File.read('notification.txt'))

print(notificationBody.result())
```

# Original Output

```
Hello dear user :)
You have 2 new notifications!<br />Your last notification was received on Monday Dec 2
8 at  7:32.

2015-12-28userX starred repo1userY forked repo2 to userY/repo22015-12-28userX starred
repo1

View your full notifications history: <site url>

Unsubscribe: <unsubscribe url>
```

# Improved Output

```
Hello dear user :)
You have 2 new notifications!<br />Your last notification was received on Monday Dec 28 at  7:32.

+ [2015-12-28] userX starred repo1
+ userY forked repo2 to userY/repo2
+ [2015-12-28] userX starred repo1

View your full notifications history: <site url>

Unsubscribe: <unsubscribe url>
```